### PR TITLE
Update script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -117,11 +117,7 @@ function displayTimings(records) {
         const placeholderRow = `
             <tr style="font-weight: normal; background-color: #f9f9f9;">
                 <td>${firstDayOfMonth}</td>
-                <td>N/A</td>
-                <td>N/A</td>
-                <td>N/A</td>
-                <td>N/A</td>
-                <td>N/A</td>
+                <td colspan="5">No timings available for this date.</td>
                 <td colspan="4">N/A</td>
             </tr>
         `;


### PR DESCRIPTION
Placeholder Row Message: If there are no timings for the first day of the month, the placeholder row now displays "No timings available for this date." instead of just "N/A".